### PR TITLE
Fix extra semicolon in import/export snippets

### DIFF
--- a/src/snippets/generated.json
+++ b/src/snippets/generated.json
@@ -795,11 +795,7 @@
   "importAs": {
     "key": "importAs",
     "prefix": "ima",
-    "body": [
-      "import { ${2:second} as ${3:third} } from '${1:first}';",
-      "$0;",
-      ""
-    ],
+    "body": ["import { ${2:second} as ${3:third} } from '${1:first}';",""],
     "scope": "typescript,typescriptreact,javascript,javascriptreact"
   },
   "importBrowserRouter": {
@@ -820,19 +816,19 @@
   "importDestructing": {
     "key": "importDestructing",
     "prefix": "imd",
-    "body": ["import { ${2:second} } from '${1:first}';", "$0;", ""],
+    "body": ["import { ${2:second} } from '${1:first}';", ""],
     "scope": "typescript,typescriptreact,javascript,javascriptreact"
   },
   "importEverything": {
     "key": "importEverything",
     "prefix": "ime",
-    "body": ["import * as ${2:second} from '${1:first}';", "$0;", ""],
+    "body": ["import * as ${2:second} from '${1:first}';", ""],
     "scope": "typescript,typescriptreact,javascript,javascriptreact"
   },
   "importNoModuleName": {
     "key": "importNoModuleName",
     "prefix": "imn",
-    "body": ["import '${1:first}';", "$0;", ""],
+    "body": ["import '${1:first}';", ""],
     "scope": "typescript,typescriptreact,javascript,javascriptreact"
   },
   "importPropTypes": {
@@ -931,7 +927,7 @@
   "import": {
     "key": "import",
     "prefix": "imp",
-    "body": ["import ${2:second} from '${1:first}';", "$0;", ""],
+    "body": ["import ${2:second} from '${1:first}';", ""],
     "scope": "typescript,typescriptreact,javascript,javascriptreact"
   },
   "propTypeArray": {
@@ -1580,7 +1576,6 @@
     "prefix": "exa",
     "body": [
       "export { ${2:second} as ${3:third} } from '${1:first}';",
-      "$0;",
       ""
     ],
     "scope": "typescript,typescriptreact,javascript,javascriptreact"

--- a/src/sourceSnippets/imports.ts
+++ b/src/sourceSnippets/imports.ts
@@ -147,14 +147,14 @@ const importSnippet: ImportsSnippet = {
   prefix: 'imp',
   body: [
     `import ${Placeholders.SecondTab} from '${Placeholders.FirstTab}'`,
-    Placeholders.LastTab,
+    '',
   ],
 };
 
 const importNoModuleName: ImportsSnippet = {
   key: 'importNoModuleName',
   prefix: 'imn',
-  body: [`import '${Placeholders.FirstTab}'`, Placeholders.LastTab],
+  body: [`import '${Placeholders.FirstTab}'`, ''],
 };
 
 const importDestructing: ImportsSnippet = {
@@ -162,7 +162,7 @@ const importDestructing: ImportsSnippet = {
   prefix: 'imd',
   body: [
     `import { ${Placeholders.SecondTab} } from '${Placeholders.FirstTab}'`,
-    Placeholders.LastTab,
+    '',
   ],
 };
 
@@ -171,7 +171,7 @@ const importEverything: ImportsSnippet = {
   prefix: 'ime',
   body: [
     `import * as ${Placeholders.SecondTab} from '${Placeholders.FirstTab}'`,
-    Placeholders.LastTab,
+    '',
   ],
 };
 
@@ -180,7 +180,7 @@ const importAs: ImportsSnippet = {
   prefix: 'ima',
   body: [
     `import { ${Placeholders.SecondTab} as ${Placeholders.ThirdTab} } from '${Placeholders.FirstTab}'`,
-    Placeholders.LastTab,
+    '',
   ],
 };
 

--- a/src/sourceSnippets/others.ts
+++ b/src/sourceSnippets/others.ts
@@ -65,7 +65,7 @@ const exportAs: OthersSnippet = {
   prefix: 'exa',
   body: [
     `export { ${Placeholders.SecondTab} as ${Placeholders.ThirdTab} } from '${Placeholders.FirstTab}'`,
-    Placeholders.LastTab,
+    '',
   ],
 };
 


### PR DESCRIPTION
Most import snippets (like imp, ima, imd) have a newline and a semicolon.